### PR TITLE
Feat/tor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Node.js CI](https://github.com/notrustverify/pastenym/actions/workflows/frontend.yml/badge.svg)](https://github.com/notrustverify/pastenym-frontend/actions/workflows/frontend.yml)
+[![Frontend CI](https://github.com/notrustverify/pastenym-frontend/actions/workflows/frontend.yml/badge.svg)](https://github.com/notrustverify/pastenym-frontend/actions/workflows/frontend.yml)
 
 # Frontend - Pastenym
 

--- a/src/context/createConnection.js
+++ b/src/context/createConnection.js
@@ -7,14 +7,17 @@ export async function connectMixnet() {
 
     let preferredGatewayIdentityKey =
         'E3mvZTHQCdBvhfr178Swx9g4QG3kkRUun7YnToLMcMbM'
-    let gatewayListener = 'wss://gateway1.nymtech.net:443'        
 
-    // start the client and connect to a gateway
+    // WSS is mandatory for HTTPS website
+    let gatewayListener = 'wss://gateway1.nymtech.net:443'
+
+    // give the possibility to not force the gateway to use. Can be useful for tor hidden service.
     if (process.env.WS_CONNECTION) {
         preferredGatewayIdentityKey = ''
         gatewayListener = ''
     }
 
+    // start the client and connect to a gateway
     await nym.client.start({
         clientId: 'pastenymClient',
         validatorApiUrl,

--- a/src/context/createConnection.js
+++ b/src/context/createConnection.js
@@ -4,16 +4,23 @@ export async function connectMixnet() {
     const nym = await createNymMixnetClient()
 
     const validatorApiUrl = 'https://validator.nymtech.net/api'
-    const preferredGatewayIdentityKey =
+
+    let preferredGatewayIdentityKey =
         'E3mvZTHQCdBvhfr178Swx9g4QG3kkRUun7YnToLMcMbM'
+    let gatewayListener = 'wss://gateway1.nymtech.net:443'        
 
     // start the client and connect to a gateway
-        await nym.client.start({
-            clientId: 'pastenymClient',
-            validatorApiUrl,
-            preferredGatewayIdentityKey,
-            gatewayListener: 'wss://gateway1.nymtech.net:443',
-        })
+    if (process.env.WS_CONNECTION) {
+        preferredGatewayIdentityKey = ''
+        gatewayListener = ''
+    }
+
+    await nym.client.start({
+        clientId: 'pastenymClient',
+        validatorApiUrl,
+        preferredGatewayIdentityKey: preferredGatewayIdentityKey,
+        gatewayListener: gatewayListener,
+    })
 
     return nym
 }


### PR DESCRIPTION
Give the possibility to not specify gateway and gatewaylistener. Could be useful for tor deployment

Note: WSS is mandatory for HTTPS